### PR TITLE
Updating external dependency versions and publishing 2.0.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to NuGet
+on:
+  push:
+    branches:
+      - master # Default release branch
+    pull_request:
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: build
+        run: dotnet build
+      - name: test
+        run: dotnet test
+  publish:
+    # Only run this job on master
+    if: github.ref == 'refs/heads/master'
+    
+    name: Publish to NuGet
+    runs-on: ubuntu-latest
+    needs: [ build ]
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      # Publish
+      - name: publish on version change
+        uses: rohith/publish-nuget@v2
+        with:
+          PROJECT_FILE_PATH: XboxAPI.NET/XboxAPI.NET.csproj # Relative to repository root
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}} # nuget.org API key

--- a/XboxAPI.NET.Tests/XboxAPI.NET.Tests/XboxAPITests.cs
+++ b/XboxAPI.NET.Tests/XboxAPI.NET.Tests/XboxAPITests.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.Threading.Tasks;
 using XboxAPI.NET.Models.V2;
 using XboxAPI.NET.XboxAPIRestClient;
-using XboxAPI.NET.Models.V2;
 
 namespace XboxAPI.NET.Tests
 {

--- a/XboxAPI.NET/XboxAPI.NET.csproj
+++ b/XboxAPI.NET/XboxAPI.NET.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
     <Authors>Matthew Chartier</Authors>
     <Company />
     <Description>Unofficial .NET client for XboxAPI. (https://xboxapi.com/)</Description>
@@ -14,10 +13,6 @@
     <PackageProjectUrl>https://github.com/MChartier/XboxAPI.NET</PackageProjectUrl>
   </PropertyGroup>
 
-  <PropertyGroup>
-    
-  </PropertyGroup>
-
   <ItemGroup>
     <None Remove="LICENSE" />
   </ItemGroup>
@@ -27,8 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="RestSharp" Version="106.6.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12,13)" />
+    <PackageReference Include="RestSharp" Version="[106.6.7,107)" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Updating external dependency versions to specify version range instead
of fixed version.
Updating package version from 2.0.2 to 2.0.3.
Adding GitHub action workflow to deploy NuGet package.